### PR TITLE
Clarify credential requirements

### DIFF
--- a/docs/jupiterone-io/jupiter-integration-jira.md
+++ b/docs/jupiterone-io/jupiter-integration-jira.md
@@ -11,8 +11,9 @@ The integration is triggered by an event containing the information for a
 specific integration instance.
 
 Customers authorize access by creating a Jira user and providing the username
-and password to JupiterOne for HTTP Basic Auth as described in the [Jira
-Security for Other Integrations][1] documentation.
+and password (or [API token][2] when passwords require MFA) to JupiterOne for
+HTTP Basic Auth as described in the [Jira Security for Other Integrations][1]
+documentation.
 
 ## Entities
 
@@ -38,3 +39,4 @@ The following relationships are created/mapped:
 
 [1]:
   https://developer.atlassian.com/cloud/jira/platform/security-for-other-integrations/
+[2]: https://confluence.atlassian.com/cloud/api-tokens-938839638.html


### PR DESCRIPTION
Users will need to generate an API Key if their Jira requires MFA with passwords.