### PR TITLE
Validate project keys in invocation validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build:docs:model": "ts-node tools/entities-relationships-table-md.ts",
     "prepack": "yarn build",
     "lint": "yarn lint:ts && yarn lint:md",
+    "type-check": "tsc",
     "lint:md": "remark .",
     "lint:ts": "tslint --project .",
     "format": "yarn prettier --write '**/*.{ts,js,json,md}'",

--- a/src/initializeContext.ts
+++ b/src/initializeContext.ts
@@ -54,7 +54,7 @@ function buildCustomFields(fields: any): string[] {
   return customFields;
 }
 
-function buildProjectConfigs(projects: any): ProjectConfig[] {
+export function buildProjectConfigs(projects: any): ProjectConfig[] {
   const projectConfigs: ProjectConfig[] = [];
 
   if (Array.isArray(projects)) {

--- a/src/invocationValidator.test.ts
+++ b/src/invocationValidator.test.ts
@@ -83,7 +83,7 @@ describe("projects", () => {
 
     const result = await invocationValidator(executionContext as any);
 
-    expect(result).toBe(true);
+    expect(result).toBeUndefined();
     nockDone();
   });
 

--- a/src/invocationValidator.test.ts
+++ b/src/invocationValidator.test.ts
@@ -2,6 +2,7 @@ import {
   IntegrationInstanceAuthenticationError,
   IntegrationInstanceConfigError,
 } from "@jupiterone/jupiter-managed-integration-sdk";
+import nock from "nock";
 import invocationValidator from "./invocationValidator";
 
 describe("invocationValidator errors", () => {
@@ -55,5 +56,58 @@ describe("invocationValidator errors", () => {
     } catch (e) {
       expect(e instanceof IntegrationInstanceAuthenticationError).toBe(true);
     }
+  });
+});
+
+describe("projects", () => {
+  beforeAll(() => {
+    nock.back.fixtures = `${__dirname}/../test/fixtures/`;
+    process.env.CI
+      ? nock.back.setMode("lockdown")
+      : nock.back.setMode("record");
+  });
+
+  test("valid projects", async () => {
+    const { nockDone } = await nock.back("invocation-projects.json");
+
+    const executionContext = {
+      instance: {
+        config: {
+          jiraHost: "fake-hostname.atlassian.net",
+          jiraUsername: "fakeLogin",
+          jiraPassword: "fakePassword",
+          projects: ["IR"],
+        },
+      },
+    };
+
+    const result = await invocationValidator(executionContext as any);
+
+    expect(result).toBe(true);
+    nockDone();
+  });
+
+  test("invalid projects", async () => {
+    const { nockDone } = await nock.back("invocation-projects.json");
+
+    const executionContext = {
+      instance: {
+        config: {
+          jiraHost: "fake-hostname.atlassian.net",
+          jiraUsername: "fakeLogin",
+          jiraPassword: "fakePassword",
+          projects: ["INVALID_PROJECT"],
+        },
+      },
+    };
+
+    try {
+      await invocationValidator(executionContext as any);
+    } catch (e) {
+      expect(e.message).toMatch(
+        'The following project key(s) are invalid: ["INVALID_PROJECT"]. Ensure the authenticated user has access to this project.',
+      );
+    }
+    nockDone();
   });
 });

--- a/src/invocationValidator.ts
+++ b/src/invocationValidator.ts
@@ -4,6 +4,7 @@ import {
   IntegrationValidationContext,
 } from "@jupiterone/jupiter-managed-integration-sdk";
 
+import { buildProjectConfigs } from "./initializeContext";
 import { createJiraClient } from "./jira";
 
 /**
@@ -23,7 +24,7 @@ import { createJiraClient } from "./jira";
  */
 export default async function invocationValidator(
   context: IntegrationValidationContext,
-) {
+): Promise<boolean | undefined> {
   const {
     instance: { config },
   } = context;
@@ -42,9 +43,28 @@ export default async function invocationValidator(
   }
 
   const provider = createJiraClient(config);
+
+  let fetchedProjectKeys: string[];
   try {
-    await provider.fetchProjects();
+    const fetchedProjects = await provider.fetchProjects();
+    fetchedProjectKeys = fetchedProjects.map(p => p.key);
   } catch (err) {
     throw new IntegrationInstanceAuthenticationError(err);
   }
+
+  const configProjectKeys = buildProjectConfigs(config.projects).map(
+    p => p.key,
+  );
+
+  const invalidConfigProjectKeys = configProjectKeys.filter(
+    k => !fetchedProjectKeys.includes(k),
+  );
+  if (invalidConfigProjectKeys.length) {
+    throw new IntegrationInstanceConfigError(
+      `The following project key(s) are invalid: ${JSON.stringify(
+        invalidConfigProjectKeys,
+      )}. Ensure the authenticated user has access to this project.`,
+    );
+  }
+  return true;
 }

--- a/src/invocationValidator.ts
+++ b/src/invocationValidator.ts
@@ -24,7 +24,7 @@ import { createJiraClient } from "./jira";
  */
 export default async function invocationValidator(
   context: IntegrationValidationContext,
-): Promise<boolean | undefined> {
+) {
   const {
     instance: { config },
   } = context;
@@ -66,5 +66,4 @@ export default async function invocationValidator(
       )}. Ensure the authenticated user has access to this project.`,
     );
   }
-  return true;
 }

--- a/test/fixtures/invocation-projects.json
+++ b/test/fixtures/invocation-projects.json
@@ -1,0 +1,66 @@
+[
+  {
+    "scope": "https://fake-hostname.atlassian.net:443",
+    "method": "GET",
+    "path": "/rest/api/3/project",
+    "body": "",
+    "status": 200,
+    "response": [
+      {
+        "expand": "description,lead,issueTypes,url,projectKeys,permissions,insight",
+        "self": "https://fake-hostname.atlassian.net/rest/api/3/project/10000",
+        "id": "10000",
+        "key": "IR",
+        "name": "IR",
+        "avatarUrls": {
+          "48x48": "https://fake-hostname.atlassian.net/secure/projectavatar?pid=10000&avatarId=10411",
+          "24x24": "https://fake-hostname.atlassian.net/secure/projectavatar?size=small&s=small&pid=10000&avatarId=10411",
+          "16x16": "https://fake-hostname.atlassian.net/secure/projectavatar?size=xsmall&s=xsmall&pid=10000&avatarId=10411",
+          "32x32": "https://fake-hostname.atlassian.net/secure/projectavatar?size=medium&s=medium&pid=10000&avatarId=10411"
+        },
+        "projectTypeKey": "software",
+        "simplified": true,
+        "style": "next-gen",
+        "isPrivate": false,
+        "properties": {},
+        "entityId": "8d216040-8772-4509-9c64-82d73fbf2122",
+        "uuid": "8d216040-8772-4509-9c64-82d73fbf2122"
+      }
+    ],
+    "rawHeaders": [
+      "Server",
+      "AtlassianProxy/1.15.8.1",
+      "Vary",
+      "Accept-Encoding",
+      "Cache-Control",
+      "no-cache, no-store, no-transform",
+      "Content-Type",
+      "application/json;charset=UTF-8",
+      "Strict-Transport-Security",
+      "max-age=315360000; includeSubDomains; preload",
+      "Date",
+      "Fri, 18 Sep 2020 01:36:01 GMT",
+      "ATL-TraceId",
+      "40565168a6689e67",
+      "X-AREQUESTID",
+      "f3da7d52-f5e2-4e7e-84c1-e5e686e78e37",
+      "X-AACCOUNTID",
+      "5f3a81033236070038805711",
+      "X-XSS-Protection",
+      "1; mode=block",
+      "Transfer-Encoding",
+      "chunked",
+      "Timing-Allow-Origin",
+      "*",
+      "X-Content-Type-Options",
+      "nosniff",
+      "Micros-Issuer",
+      "micros/edge-authenticator",
+      "Connection",
+      "close",
+      "Set-Cookie",
+      "Expect-CT",
+      "report-uri=\"https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy\", enforce, max-age=86400"
+    ]
+  }
+]


### PR DESCRIPTION
The `graph-jira` project accepts a `projects` configuration variable of comma-separated project names, e.g. `LO,J1,SECOPS`. These configurations are not validated in the validation config and throw confusing errors in the middle of downstream steps. 

This PR validates project names in `invocationValidation` and throws user-friendly errors.