### PR TITLE
Updated regex to allow directories in hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased](https://github.com/JuptiterOne/graph-jira/compare/v1.9.8...HEAD)
 
+### Changed
+
+- Loosened the hostname validating regex to allow example.atlassian.net/jira
+
 ## [1.11.0] - 2021-06-04
 
 - Add the functionality to create an issue with a specific class.

--- a/src/invocationValidator.test.ts
+++ b/src/invocationValidator.test.ts
@@ -82,11 +82,10 @@ describe("invocationValidator errors", () => {
         config: {
           jiraHost: "test.com/subdir",
           jiraUsername: "testLogin",
-          jiraPassword: "fakePassword",
+          jiraPassword: "testPassword",
         },
       },
     };
-    expect.assertions(1);
     expect(await invocationValidator(context as any)).toReturn;
   });
 });

--- a/src/invocationValidator.test.ts
+++ b/src/invocationValidator.test.ts
@@ -76,7 +76,7 @@ describe("invocationValidator errors", () => {
     }
   });
 
-  test("should not throw exception if jiraHost has a subdir", async () => {
+  test("should throw auth error not instanceConfigError if jiraHost has a subdir", async () => {
     const context = {
       instance: {
         config: {
@@ -86,7 +86,11 @@ describe("invocationValidator errors", () => {
         },
       },
     };
-    expect(await invocationValidator(context as any)).toReturn;
+    try {
+      await invocationValidator(context as any);
+    } catch (e) {
+      expect(e instanceof IntegrationInstanceAuthenticationError).toBe(true);
+    }
   });
 });
 

--- a/src/invocationValidator.test.ts
+++ b/src/invocationValidator.test.ts
@@ -57,6 +57,38 @@ describe("invocationValidator errors", () => {
       expect(e instanceof IntegrationInstanceAuthenticationError).toBe(true);
     }
   });
+
+  test("should throw exception if jiraHost has invalid chars", async () => {
+    const context = {
+      instance: {
+        config: {
+          jiraHost: "test.com?somequeryparms",
+          jiraUsername: "testLogin",
+          jiraPassword: "testPassword",
+        },
+      },
+    };
+    expect.assertions(1);
+    try {
+      await invocationValidator(context as any);
+    } catch (err) {
+      expect(err instanceof IntegrationInstanceConfigError).toBeTruthy();
+    }
+  });
+
+  test("should not throw exception if jiraHost has a subdir", async () => {
+    const context = {
+      instance: {
+        config: {
+          jiraHost: "test.com/subdir",
+          jiraUsername: "testLogin",
+          jiraPassword: "fakePassword",
+        },
+      },
+    };
+    expect.assertions(1);
+    expect(await invocationValidator(context as any)).toReturn;
+  });
 });
 
 describe("projects", () => {

--- a/src/invocationValidator.ts
+++ b/src/invocationValidator.ts
@@ -35,7 +35,7 @@ export default async function invocationValidator(
     );
   }
 
-  const hostnameRegex = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
+  const hostnameRegex = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9/][A-Za-z0-9-/]*[A-Za-z0-9])$/;
   if (!config.jiraHost.match(hostnameRegex)) {
     throw new IntegrationInstanceConfigError(
       "config.jiraHost must be a valid hostname",


### PR DESCRIPTION
Hi @mknoedel  and @aiwilliams !

Per Jira INT-1243, the customer wants to use a directory appended to their hostname, but our validating regex is too strict. So this updates it to allow `example.atlassian.net/jira` instead of just `example.atlassian.net`. 

That said, there could still be a problem in the Jira client (jira-node) that objects to this. I can't be sure. I tried testing it, and I think the Jira client is not complaining, but I don't have an actual local Jira instance in a subdir, and my test using a Linux redirect in /etc/hosts caused the real Jira host to detect a DDOS attack. :)  but jira-node didn't complain, so I'm thinking that in the customer's real-world on-prem deployment, it'll work. 

In any event, this loosening of the validating regex feels low-stakes to me. So this PR is to merge the fix in to the current old SDK in production. I also made a PR to put the change into the new SDK when we are ready for that. 

Kevin