### PR TITLE
Adding Issue class to jira_issue, pkg updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased](https://github.com/JuptiterOne/graph-jira/compare/v1.9.8...HEAD)
 
+### Added
+
+- Added Issue class to `jira_issue` entities
+
 ## [2.1.3] - 2021-08-17
 
 ### Removed

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -160,7 +160,7 @@ NOTE: ALL OF THE FOLLOWING DOCUMENTATION IS GENERATED USING THE
 "j1-integration document" COMMAND. DO NOT EDIT BY HAND! PLEASE SEE THE DEVELOPER
 DOCUMENTATION FOR USAGE INFORMATION:
 
-https://github.com/JupiterOne/sdk/blob/master/docs/integrations/development.md
+https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
 ********************************************************************************
 -->
 
@@ -170,16 +170,16 @@ https://github.com/JupiterOne/sdk/blob/master/docs/integrations/development.md
 
 The following entities are created:
 
-| Resources    | Entity `_type` | Entity `_class` |
-| ------------ | -------------- | --------------- |
-| Account      | `jira_account` | `Account`       |
-| Jira Issue   | `jira_issue`   | `Record`        |
-| Jira Project | `jira_project` | `Project`       |
-| Jira User    | `jira_user`    | `User`          |
+| Resources    | Entity `_type` | Entity `_class`   |
+| ------------ | -------------- | ----------------- |
+| Account      | `jira_account` | `Account`         |
+| Jira Issue   | `jira_issue`   | `Record`, `Issue` |
+| Jira Project | `jira_project` | `Project`         |
+| Jira User    | `jira_user`    | `User`            |
 
 ### Relationships
 
-The following relationships are created/mapped:
+The following relationships are created:
 
 | Source Entity `_type` | Relationship `_class` | Target Entity `_type` |
 | --------------------- | --------------------- | --------------------- |

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.10.0",
+    "@jupiterone/integration-sdk-core": "^6.22.1",
     "dotenv": "^10.0.0",
-    "jira-client": "^6.21.1"
+    "jira-client": "^6.22.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -39,8 +39,8 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-typescript": "^7.1.0",
-    "@jupiterone/integration-sdk-dev-tools": "^6.10.0",
-    "@jupiterone/integration-sdk-testing": "^6.10.0",
+    "@jupiterone/integration-sdk-dev-tools": "^6.22.1",
+    "@jupiterone/integration-sdk-testing": "^6.22.1",
     "@types/bunyan": "^1.8.5",
     "@types/fs-extra": "^7.0.0",
     "@types/gremlin": "^3.4.2",

--- a/src/converters/IssueEntityConverter.test.ts
+++ b/src/converters/IssueEntityConverter.test.ts
@@ -1,50 +1,50 @@
-import { createMockIntegrationLogger } from "@jupiterone/integration-sdk-testing";
-import { createIssueEntity } from ".";
-import { buildCustomFields } from "../utils/builders";
-import { Issue } from "../jira";
-import generateEntityKey from "../utils/generateEntityKey";
-import merge from "lodash.merge";
-import { parseTimePropertyValue } from "@jupiterone/integration-sdk-core";
+import { createMockIntegrationLogger } from '@jupiterone/integration-sdk-testing';
+import { createIssueEntity } from '.';
+import { buildCustomFields } from '../utils/builders';
+import { Issue } from '../jira';
+import generateEntityKey from '../utils/generateEntityKey';
+import merge from 'lodash.merge';
+import { parseTimePropertyValue } from '@jupiterone/integration-sdk-core';
 
 function getJiraIssue(overrides: object = {}): Issue {
   return merge<Issue, any>(
     {
       expand:
-        "operations,versionedRepresentations,editmeta,changelog,renderedFields",
-      id: "47788",
-      self: "https://test.atlassian.net/rest/api/3/issue/47788",
-      key: "J1TEMP-112",
+        'operations,versionedRepresentations,editmeta,changelog,renderedFields',
+      id: '47788',
+      self: 'https://test.atlassian.net/rest/api/3/issue/47788',
+      key: 'J1TEMP-112',
       fields: {
-        statuscategorychangedate: "2020-03-07T14:11:35.283-0500",
+        statuscategorychangedate: '2020-03-07T14:11:35.283-0500',
         issuetype: {
-          self: "https://test.atlassian.net/rest/api/3/issuetype/10302",
-          name: "Risk",
+          self: 'https://test.atlassian.net/rest/api/3/issuetype/10302',
+          name: 'Risk',
         },
         timespent: null,
         project: {
-          self: "https://test.atlassian.net/rest/api/3/project/10313",
-          url: "https://test.atlassian.net/rest/api/3/project/10313",
-          id: "10313",
-          key: "J1TEMP",
-          name: "JupiterOne Temp",
-          projectTypeKey: "software",
+          self: 'https://test.atlassian.net/rest/api/3/project/10313',
+          url: 'https://test.atlassian.net/rest/api/3/project/10313',
+          id: '10313',
+          key: 'J1TEMP',
+          name: 'JupiterOne Temp',
+          projectTypeKey: 'software',
           simplified: false,
-          style: "basic",
+          style: 'basic',
           isPrivate: false,
           avatarUrls: {
-            "48x48":
-              "https://test.atlassian.net/secure/projectavatar?pid=10313&avatarId=10665",
-            "24x24":
-              "https://test.atlassian.net/secure/projectavatar?size=small&s=small&pid=10313&avatarId=10665",
-            "16x16":
-              "https://test.atlassian.net/secure/projectavatar?size=xsmall&s=xsmall&pid=10313&avatarId=10665",
-            "32x32":
-              "https://test.atlassian.net/secure/projectavatar?size=medium&s=medium&pid=10313&avatarId=10665",
+            '48x48':
+              'https://test.atlassian.net/secure/projectavatar?pid=10313&avatarId=10665',
+            '24x24':
+              'https://test.atlassian.net/secure/projectavatar?size=small&s=small&pid=10313&avatarId=10665',
+            '16x16':
+              'https://test.atlassian.net/secure/projectavatar?size=xsmall&s=xsmall&pid=10313&avatarId=10665',
+            '32x32':
+              'https://test.atlassian.net/secure/projectavatar?size=medium&s=medium&pid=10313&avatarId=10665',
           },
         },
         fixVersions: [],
         aggregatetimespent: null,
-        customfield_10430: "myLaptop",
+        customfield_10430: 'myLaptop',
         customfield_10431: null,
         resolution: null,
         customfield_10310: null,
@@ -54,23 +54,23 @@ function getJiraIssue(overrides: object = {}): Issue {
           hasEpicLinkFieldDependency: false,
           showField: false,
           nonEditableReason: {
-            reason: "PLUGIN_LICENSE_ERROR",
+            reason: 'PLUGIN_LICENSE_ERROR',
             message:
-              "Portfolio for Jira must be licensed for the Parent Link to be available.",
+              'Portfolio for Jira must be licensed for the Parent Link to be available.',
           },
         },
         customfield_10312: null,
         customfield_10433: {
           // doc object field (idk where this is in the documentation)
           version: 1,
-          type: "doc",
+          type: 'doc',
           content: [
             {
-              type: "paragraph",
+              type: 'paragraph',
               content: [
                 {
-                  type: "text",
-                  text: "there is none",
+                  type: 'text',
+                  text: 'there is none',
                 },
               ],
             },
@@ -83,43 +83,42 @@ function getJiraIssue(overrides: object = {}): Issue {
         customfield_10424: null,
         customfield_10304: null,
         customfield_10425: {
-          self: "https://test.atlassian.net/rest/api/3/customFieldOption/10340",
-          value: "3 - High / Certain",
-          id: "10340",
+          self: 'https://test.atlassian.net/rest/api/3/customFieldOption/10340',
+          value: '3 - High / Certain',
+          id: '10340',
         },
         customfield_10426: {
-          self: "https://test.atlassian.net/rest/api/3/customFieldOption/10343",
-          value: "3 - High",
-          id: "10343",
+          self: 'https://test.atlassian.net/rest/api/3/customFieldOption/10343',
+          value: '3 - High',
+          id: '10343',
         },
         customfield_10305: null,
         customfield_10306: null,
         customfield_10307: null,
         customfield_10428: {
           // standard object field
-          self: "https://test.atlassian.net/rest/api/3/customFieldOption/10353",
-          value: "9",
-          id: "10353",
+          self: 'https://test.atlassian.net/rest/api/3/customFieldOption/10353',
+          value: '9',
+          id: '10353',
         },
-        resolutiondate: "2020-03-07T14:11:35.017-0500",
+        resolutiondate: '2020-03-07T14:11:35.017-0500',
         customfield_10429: null,
         customfield_10308: null,
         customfield_10309: null,
         workratio: -1,
         lastViewed: null,
         watches: {
-          self:
-            "https://test.atlassian.net/rest/api/3/issue/J1TEMP-112/watchers",
+          self: 'https://test.atlassian.net/rest/api/3/issue/J1TEMP-112/watchers',
           watchCount: 1,
           isWatching: false,
         },
-        created: "2020-03-07T14:11:35.040-0500",
+        created: '2020-03-07T14:11:35.040-0500',
         customfield_10100: null,
         priority: {
           // self: "https://test.atlassian.net/rest/api/3/priority/3",
           // iconUrl: "https://test.atlassian.net/images/icons/priorities/medium.svg",
-          name: "Medium",
-          id: "3",
+          name: 'Medium',
+          id: '3',
         },
         customfield_10101: null,
         customfield_10420: null,
@@ -131,14 +130,14 @@ function getJiraIssue(overrides: object = {}): Issue {
         customfield_10422: null,
         customfield_10414: {
           version: 1,
-          type: "doc",
+          type: 'doc',
           content: [
             {
-              type: "paragraph",
+              type: 'paragraph',
               content: [
                 {
-                  type: "text",
-                  text: "nothing can be done",
+                  type: 'text',
+                  text: 'nothing can be done',
                 },
               ],
             },
@@ -150,44 +149,44 @@ function getJiraIssue(overrides: object = {}): Issue {
         customfield_10419: null,
         issuelinks: [],
         // assignee: null,
-        updated: "2020-03-07T20:51:56.951-0500",
+        updated: '2020-03-07T20:51:56.951-0500',
         status: {
-          self: "https://test.atlassian.net/rest/api/3/status/1",
+          self: 'https://test.atlassian.net/rest/api/3/status/1',
           description:
-            "The issue is open and ready for the assignee to start work on it.",
-          name: "Open",
-          id: "1",
-          key: "key",
-          colorName: "green",
+            'The issue is open and ready for the assignee to start work on it.',
+          name: 'Open',
+          id: '1',
+          key: 'key',
+          colorName: 'green',
           statusCategory: {
-            self: "https://test.atlassian.net/rest/api/3/statuscategory/2",
-            id: "2",
-            key: "new",
-            colorName: "blue-gray",
-            name: "To Do",
+            self: 'https://test.atlassian.net/rest/api/3/statuscategory/2',
+            id: '2',
+            key: 'new',
+            colorName: 'blue-gray',
+            name: 'To Do',
           },
         },
         components: [],
         timeoriginalestimate: null,
         description: {
           // version: 1,
-          type: "doc",
+          type: 'doc',
           content: [
             {
-              type: "paragraph",
+              type: 'paragraph',
               content: [
                 {
-                  type: "text",
-                  text: "edit",
+                  type: 'text',
+                  text: 'edit',
                 },
               ],
             },
             {
-              type: "paragraph",
+              type: 'paragraph',
               content: [
                 {
-                  type: "text",
-                  text: "edit 2",
+                  type: 'text',
+                  text: 'edit 2',
                 },
               ],
             },
@@ -204,55 +203,53 @@ function getJiraIssue(overrides: object = {}): Issue {
         customfield_10407: null,
         customfield_10408: null,
         customfield_10409: null,
-        summary: "Test Custom Field",
+        summary: 'Test Custom Field',
         creator: {
-          self:
-            "https://test.atlassian.net/rest/api/3/user?accountId=557058%3Ac1f2ea6e-5675-456e-a9ec-b37a43aaeeb5",
-          accountId: "557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5",
-          emailAddress: "adamz@company.com",
-          name: "adamz@company.com",
+          self: 'https://test.atlassian.net/rest/api/3/user?accountId=557058%3Ac1f2ea6e-5675-456e-a9ec-b37a43aaeeb5',
+          accountId: '557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5',
+          emailAddress: 'adamz@company.com',
+          name: 'adamz@company.com',
           avatarUrls: {
-            "48x48":
-              "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=48&s=48",
-            "24x24":
-              "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=24&s=24",
-            "16x16":
-              "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=16&s=16",
-            "32x32":
-              "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=32&s=32",
+            '48x48':
+              'https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=48&s=48',
+            '24x24':
+              'https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=24&s=24',
+            '16x16':
+              'https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=16&s=16',
+            '32x32':
+              'https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=32&s=32',
           },
-          displayName: "Adam Z",
+          displayName: 'Adam Z',
           active: true,
-          timeZone: "America/New_York",
-          accountType: "atlassian",
+          timeZone: 'America/New_York',
+          accountType: 'atlassian',
         },
         subtasks: [],
         reporter: {
-          self:
-            "https://test.atlassian.net/rest/api/3/user?accountId=557058%3Ac1f2ea6e-5675-456e-a9ec-b37a43aaeeb5",
-          accountId: "557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5",
-          emailAddress: "adamz@company.com",
-          name: "adamz@company.com",
+          self: 'https://test.atlassian.net/rest/api/3/user?accountId=557058%3Ac1f2ea6e-5675-456e-a9ec-b37a43aaeeb5',
+          accountId: '557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5',
+          emailAddress: 'adamz@company.com',
+          name: 'adamz@company.com',
           avatarUrls: {
-            "48x48":
-              "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=48&s=48",
-            "24x24":
-              "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=24&s=24",
-            "16x16":
-              "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=16&s=16",
-            "32x32":
-              "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=32&s=32",
+            '48x48':
+              'https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=48&s=48',
+            '24x24':
+              'https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=24&s=24',
+            '16x16':
+              'https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=16&s=16',
+            '32x32':
+              'https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:c1f2ea6e-5675-456e-a9ec-b37a43aaeeb5/842225ef-15aa-41fa-9ee4-0eafd421e3c3/128?size=32&s=32',
           },
-          displayName: "Adam Z",
+          displayName: 'Adam Z',
           active: true,
-          timeZone: "America/New_York",
-          accountType: "atlassian",
+          timeZone: 'America/New_York',
+          accountType: 'atlassian',
         },
         aggregateprogress: {
           progress: 0,
           total: 0,
         },
-        customfield_10000: "{}",
+        customfield_10000: '{}',
         customfield_10001: null,
         customfield_10320: null,
         customfield_10321: null,
@@ -261,7 +258,7 @@ function getJiraIssue(overrides: object = {}): Issue {
         customfield_10323: null,
         customfield_10115: null,
         customfield_10313: null,
-        customfield_10116: "1|i03p27:", // string field
+        customfield_10116: '1|i03p27:', // string field
         customfield_10314: null,
         customfield_10436: null,
         environment: null,
@@ -277,7 +274,7 @@ function getJiraIssue(overrides: object = {}): Issue {
           total: 0,
         },
         votes: {
-          self: "https://test.atlassian.net/rest/api/3/issue/J1TEMP-112/votes",
+          self: 'https://test.atlassian.net/rest/api/3/issue/J1TEMP-112/votes',
           votes: 0,
           hasVoted: false,
         },
@@ -287,58 +284,58 @@ function getJiraIssue(overrides: object = {}): Issue {
   );
 }
 
-describe("createIssueEntity", () => {
-  test("ingests correctly", () => {
+describe('createIssueEntity', () => {
+  test('ingests correctly', () => {
     const jiraIssue = getJiraIssue();
 
     const fieldsById = {
       customfield_10428: {
-        name: "CVSS+CE",
+        name: 'CVSS+CE',
       },
       customfield_10433: {
-        name: "Residual Risk",
+        name: 'Residual Risk',
       },
       customfield_10319: {
-        name: "Number-Field",
+        name: 'Number-Field',
       },
       customfield_10116: {
-        name: "String field",
+        name: 'String field',
       },
     };
 
     const customFieldsToInclude = buildCustomFields([
-      "cvssCe", // search by name -- customfield_10428
-      "10433", // search by id -- customfield_10433
-      "customfield_10319", // handles number values
-      "customfield_10116", // handles string values
+      'cvssCe', // search by name -- customfield_10428
+      '10433', // search by id -- customfield_10433
+      'customfield_10319', // handles number values
+      'customfield_10116', // handles string values
     ]);
 
     const customFields = {
       cvssCe: 9,
-      residualRisk: "there is none",
-      stringField: "1|i03p27:",
+      residualRisk: 'there is none',
+      stringField: '1|i03p27:',
       numberField: 1234,
     };
     const jiraIssueEntity = {
-      _key: generateEntityKey("jira_issue", "47788"),
-      _type: "jira_issue",
-      _class: ["Risk", "Record"],
-      _rawData: [{ name: "default", rawData: jiraIssue }],
+      _key: generateEntityKey('jira_issue', '47788'),
+      _type: 'jira_issue',
+      _class: ['Risk', 'Record', 'Issue'],
+      _rawData: [{ name: 'default', rawData: jiraIssue }],
       ...customFields,
-      id: "47788",
-      key: "J1TEMP-112",
-      name: "J1TEMP-112",
-      displayName: "J1TEMP-112",
-      summary: "Test Custom Field",
-      description: "edit\n\nedit 2",
-      category: "issue",
+      id: '47788',
+      key: 'J1TEMP-112',
+      name: 'J1TEMP-112',
+      displayName: 'J1TEMP-112',
+      summary: 'Test Custom Field',
+      description: 'edit\n\nedit 2',
+      category: 'issue',
       webLink: `https://test.atlassian.net/browse/J1TEMP-112`,
-      status: "Open",
+      status: 'Open',
       active: true,
-      issueType: "Risk",
-      reporter: "adamz@company.com",
+      issueType: 'Risk',
+      reporter: 'adamz@company.com',
       assignee: undefined,
-      creator: "adamz@company.com",
+      creator: 'adamz@company.com',
       createdOn: parseTimePropertyValue(jiraIssue.fields.created),
       updatedOn: parseTimePropertyValue(jiraIssue.fields.updated),
       resolvedOn: parseTimePropertyValue(jiraIssue.fields.resolutiondate),
@@ -346,7 +343,7 @@ describe("createIssueEntity", () => {
       resolution: undefined,
       labels: [],
       components: [],
-      priority: "Medium",
+      priority: 'Medium',
     };
     expect(
       createIssueEntity({
@@ -358,27 +355,27 @@ describe("createIssueEntity", () => {
     ).toEqual(jiraIssueEntity);
   });
 
-  test("handles exceptions correctly", () => {
+  test('handles exceptions correctly', () => {
     const jiraIssue = getJiraIssue({
-      fields: { issuetype: { name: "Exception" } },
+      fields: { issuetype: { name: 'Exception' } },
     });
-    jiraIssue.fields.issuetype.name = "Exception";
+    jiraIssue.fields.issuetype.name = 'Exception';
     expect(
       createIssueEntity({
         issue: jiraIssue,
         logger: createMockIntegrationLogger(),
       })._class,
-    ).toEqual(["Finding", "Record"]);
+    ).toEqual(['Finding', 'Record', 'Issue']);
   });
 
-  test("handles requested class correctly", () => {
+  test('handles requested class correctly', () => {
     const jiraIssue = getJiraIssue();
     expect(
       createIssueEntity({
         issue: jiraIssue,
         logger: createMockIntegrationLogger(),
-        requestedClass: "SomeClass",
+        requestedClass: 'SomeClass',
       })._class,
-    ).toEqual(["Record", "SomeClass"]);
+    ).toEqual(['Record', 'Issue', 'SomeClass']);
   });
 });

--- a/src/converters/IssueEntityConverter.ts
+++ b/src/converters/IssueEntityConverter.ts
@@ -84,7 +84,7 @@ export function createIssueEntity({
   let issueClass: string | string[];
 
   if (requestedClass) {
-    issueClass = ['Record', requestedClass as string];
+    issueClass = ['Record', 'Issue', requestedClass as string];
   } else {
     switch ((issueType || '').toLowerCase()) {
       case 'change':

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -71,9 +71,9 @@ export interface IssueEntity extends Entity {
 }
 
 export const ISSUE_ENTITY_TYPE = 'jira_issue';
-export const ISSUE_ENTITY_CLASS = ['Record'];
-export const CHANGE_ISSUE_ENTITY_CLASS = ['Change', 'Record'];
-export const FINDING_ISSUE_ENTITY_CLASS = ['Finding', 'Record'];
-export const INCIDENT_ISSUE_ENTITY_CLASS = ['Incident', 'Record'];
-export const RISK_ISSUE_ENTITY_CLASS = ['Risk', 'Record'];
-export const VULN_ISSUE_ENTITY_CLASS = ['Vulnerability', 'Record'];
+export const ISSUE_ENTITY_CLASS = ['Record', 'Issue'];
+export const CHANGE_ISSUE_ENTITY_CLASS = ['Change', 'Record', 'Issue'];
+export const FINDING_ISSUE_ENTITY_CLASS = ['Finding', 'Record', 'Issue'];
+export const INCIDENT_ISSUE_ENTITY_CLASS = ['Incident', 'Record', 'Issue'];
+export const RISK_ISSUE_ENTITY_CLASS = ['Risk', 'Record', 'Issue'];
+export const VULN_ISSUE_ENTITY_CLASS = ['Vulnerability', 'Record', 'Issue'];

--- a/src/steps/__snapshots__/index.test.ts.snap
+++ b/src/steps/__snapshots__/index.test.ts.snap
@@ -451,6 +451,7 @@ Object {
     Object {
       "_class": Array [
         "Record",
+        "Issue",
       ],
       "_key": "jira_issue_10001",
       "_rawData": Array [
@@ -641,6 +642,7 @@ Object {
     Object {
       "_class": Array [
         "Record",
+        "Issue",
       ],
       "_key": "jira_issue_10000",
       "_rawData": Array [

--- a/src/steps/index.test.ts
+++ b/src/steps/index.test.ts
@@ -115,7 +115,7 @@ test('should collect data', async () => {
   );
   expect(issues.length).toBeGreaterThan(0);
   expect(issues).toMatchGraphObjectSchema({
-    _class: ['Record'], //this could actually have multiples in some cases
+    _class: ['Record', 'Issue'], //this could actually have more classes in some cases
     schema: {
       additionalProperties: true,
       properties: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,44 +1233,46 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jupiterone/data-model@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.32.0.tgz#2d2fae02b6c077b30f567d76989fc1c9bee1e51a"
-  integrity sha512-QORfi+8fIrbxHbLoc/v1y2vR0grC7qy8dt/jhRhncGHVyTwuruagqaKsJrKmv1BHbUzrkmOTIMRbeBEf5Gw/vw==
+"@jupiterone/data-model@^0.39.0":
+  version "0.39.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.39.0.tgz#3fa750480bc2dd63c9cbf37fa08cdb17cc74bd26"
+  integrity sha512-AZjDtRC1LlWtJGHqTthVfUSS6PBrDeNMXV4zMN42m5mFdYoDZ7OXXVxzXCtt0nlwK1zpBCClMUn5qIDeBtFR9A==
   dependencies:
     ajv "^8.0.0"
     ajv-formats "^2.0.0"
 
-"@jupiterone/integration-sdk-cli@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-6.10.0.tgz#9696244632ab5fedfc047951b058fc843739450f"
-  integrity sha512-DyCv21DGzX/KDGb98PHp4sTeS+wBeuGV0cD6u9wvdSzmWnlTQYfzcmSe1RY2BjTJaoszHTCwht0codAd18tVCQ==
+"@jupiterone/integration-sdk-cli@^6.22.1":
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-6.22.1.tgz#34c078d7c09829a8cb5743ac347d706fff25c123"
+  integrity sha512-zQiOfTiJ3DvUgYgRxWumA6Ez1j+VuSWxIVjOab9MyPEBQ5u3a+8nG4IgnW5qwUUgVG2iRpy0V0tNM8vStSbH9A==
   dependencies:
-    "@jupiterone/integration-sdk-runtime" "^6.10.0"
+    "@jupiterone/integration-sdk-runtime" "^6.22.1"
     commander "^5.0.0"
     globby "^11.0.0"
+    js-yaml "^4.1.0"
     json-diff "^0.5.4"
     lodash "^4.17.19"
     markdown-table "^2.0.0"
+    runtypes "5.1.0"
     upath "^1.2.0"
     vis "^4.21.0-EOL"
 
-"@jupiterone/integration-sdk-core@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-6.10.0.tgz#72f634395369200548ff69eb0167f9b1866a3b83"
-  integrity sha512-HtGiN8mUbiYhLUOuypBzvI9L2vw0eIuuCrvhFkR8QuunIIFXDuAgOxT64Hu+NCDSvM06s+fuqNcDovcBQFsufw==
+"@jupiterone/integration-sdk-core@^6.22.1":
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-6.22.1.tgz#5d60e281eb43c6d4d55982268d5b91fe03c9335d"
+  integrity sha512-cXaD7O0PcgrW+SINWN+dtLaST0Dz3RB/o96CA+pHEY2bxBcbNHB7w6I4mkmCcJFWGMIWuwXkwNTmywNB2Mp8Xw==
   dependencies:
-    "@jupiterone/data-model" "^0.32.0"
+    "@jupiterone/data-model" "^0.39.0"
     lodash "^4.17.21"
     uuid "^8.3.2"
 
-"@jupiterone/integration-sdk-dev-tools@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-6.10.0.tgz#8157a6d3aa9e57f496334499b2f33d86a0f09560"
-  integrity sha512-HDo30MCkLMx/nZe9Pt/oMbxkTZ3g2Ya7pTJmY0kkC6J6W8pp+8R35aHWyeoPHZnN5eLoRtF+S2QL5l1GSLohDw==
+"@jupiterone/integration-sdk-dev-tools@^6.22.1":
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-6.22.1.tgz#4dd9684017eb41a4e3564906c61dfa504e800c0b"
+  integrity sha512-fV4AuyZ11HKXLqPvbx3vXWAtRL1GThC8lSURazObqvlcVidUSaRrmGVGhH83bX/bX8SgPeJtMJ0xhYEvmlklBA==
   dependencies:
-    "@jupiterone/integration-sdk-cli" "^6.10.0"
-    "@jupiterone/integration-sdk-testing" "^6.10.0"
+    "@jupiterone/integration-sdk-cli" "^6.22.1"
+    "@jupiterone/integration-sdk-testing" "^6.22.1"
     "@types/jest" "^25.2.3"
     "@types/node" "^14.0.5"
     "@typescript-eslint/eslint-plugin" "^4.22.0"
@@ -1286,12 +1288,12 @@
     ts-node "^9.1.1"
     typescript "^4.2.4"
 
-"@jupiterone/integration-sdk-runtime@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-6.10.0.tgz#cd6e6e66a0a961613c016606e58559c23f1dbb9b"
-  integrity sha512-GLhcr7r2ac9hNjiESJn7r40UbcpcaG84TPQHQJ+yPtOKNCqfk1hgyjVH9pT+MwvVFh5wpR6+UrKP2IfUrH45Mw==
+"@jupiterone/integration-sdk-runtime@^6.22.1":
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-6.22.1.tgz#46ce267bc815f6993d375840e4a691f692331a16"
+  integrity sha512-jnZyDs7cgpx0JT5h2H6sdoTKu+7DazwdCZ/0epR25bEpuoOKnrjFoue+Ei/rRrX5nibNItNdXhna1qsVz5MNjQ==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^6.10.0"
+    "@jupiterone/integration-sdk-core" "^6.22.1"
     "@lifeomic/alpha" "^1.4.0"
     "@lifeomic/attempt" "^3.0.0"
     async-sema "^3.1.0"
@@ -1309,13 +1311,13 @@
     rimraf "^3.0.2"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-testing@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-6.10.0.tgz#f41404da14f769862b2621409dbe3042501076e5"
-  integrity sha512-DRs5eV0HPITYJsfSCCxO0WybjgAweh+Ku47NJK3djZSE7mXk9zDUNl8sVfqpei4Xyfp519JYbI4XCc3lCFuisQ==
+"@jupiterone/integration-sdk-testing@^6.22.1":
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-6.22.1.tgz#53c9a70ed4aca89711ad79cd24509ec7c60b1d1f"
+  integrity sha512-qAs9eeGk6mUvrUFOXT5Si6jIKcjjziwdzrZUkQHyZQzl2XE5pQMWKyiMJR4UgV4+0DZo8BfZCCcaIk/cXrKlEg==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^6.10.0"
-    "@jupiterone/integration-sdk-runtime" "^6.10.0"
+    "@jupiterone/integration-sdk-core" "^6.22.1"
+    "@jupiterone/integration-sdk-runtime" "^6.22.1"
     "@pollyjs/adapter-node-http" "^4.0.4"
     "@pollyjs/core" "^4.0.4"
     "@pollyjs/persister-fs" "^4.0.4"
@@ -1987,6 +1989,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -4746,10 +4753,10 @@ jest@^26.0.1:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-jira-client@^6.21.1:
-  version "6.21.1"
-  resolved "https://registry.yarnpkg.com/jira-client/-/jira-client-6.21.1.tgz#34ad42ada04432e1490f2058c901ddd7e6dd3452"
-  integrity sha512-I9HyNNEOA7ZMJO7uLSyEZKk4oXkYct+kspy9/tbBOOvK9xsZI034p1GxGdTpyV6LyRB/Rd5IRJCS4IpDp6EzZw==
+jira-client@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/jira-client/-/jira-client-6.22.0.tgz#99d64ca6a7eb98074cbaf94c5b446e14d8b9d950"
+  integrity sha512-GpwCf66/d5oN9iTMarBxAe+BYXskg5Z8RY2lUagVvPh23kV2dj50pZ/u9KzKQMERRYvGgLAUmtRct4t0NH5bOA==
   dependencies:
     "@babel/runtime" "^7.6.0"
     request "^2.88.0"
@@ -4777,6 +4784,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -6231,6 +6245,11 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+runtypes@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/runtypes/-/runtypes-5.1.0.tgz#a1f2501b5ca8fda47d51ea15b6ccca45e924a8c3"
+  integrity sha512-OMHkz6dxysXj4E8Fj/HCGjtdJUhapQUN7puvqzuzvjaX28pd52PZmEMqQlkIzCfKdhXdM0ghx8PpvELprEnOLQ==
 
 rxjs@^6.6.7:
   version "6.6.7"


### PR DESCRIPTION
We've added `Issue` to the data model classes, and GitHub now has `github_issue` with class `Issue`, so it seems analogous that `jira_issue` should also. However, for backwards compatibility, I left the `Record` class on `jira_issue`.

Also updated packages.