### PR TITLE
fixing package.json to use peerDependencies for integration-sdk-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^6.10.0",
     "dotenv": "^10.0.0",
     "jira-client": "^6.21.1"
+  },
+  "peerDependencies": {
+    "@jupiterone/integration-sdk-core": "^6.14.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -39,8 +41,8 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-typescript": "^7.1.0",
-    "@jupiterone/integration-sdk-dev-tools": "^6.10.0",
-    "@jupiterone/integration-sdk-testing": "^6.10.0",
+    "@jupiterone/integration-sdk-dev-tools": "^6.14.0",
+    "@jupiterone/integration-sdk-testing": "^6.14.0",
     "@types/bunyan": "^1.8.5",
     "@types/fs-extra": "^7.0.0",
     "@types/gremlin": "^3.4.2",


### PR DESCRIPTION
Fixing package.json to use peerDependencies for integration-sdk-core to avoid exception thrown to Sentry.