### PR TITLE
NO-TICKET - Custom field array fields will stay arrays instead of becoming a csv

### DIFF
--- a/src/converters/extractValueFromCustomField.test.ts
+++ b/src/converters/extractValueFromCustomField.test.ts
@@ -51,15 +51,15 @@ describe('extractValueFromCustomField', () => {
   });
   it('should extact the value of a MultiGroupPicker correctly', () => {
     const value = extractValueFromCustomField(MultiGroupPicker);
-    expect(value).toEqual('admins,jira-developers,jira-users');
+    expect(value).toEqual(['admins','jira-developers','jira-users']);
   });
   it('should extact the value of a MultiSelect correctly', () => {
     const value = extractValueFromCustomField(MultiSelect);
-    expect(value).toEqual('red,blue,green');
+    expect(value).toEqual(['red','blue','green']);
   });
   it('should extact the value of a MultiUserPicker correctly', () => {
     const value = extractValueFromCustomField(MultiUserPicker);
-    expect(value).toEqual('charlie,bjones,tdurden');
+    expect(value).toEqual(['charlie','bjones','tdurden']);
   });
   it('should extact the value of a NumberField correctly', () => {
     const value = extractValueFromCustomField(NumberField);
@@ -95,6 +95,6 @@ describe('extractValueFromCustomField', () => {
   });
   it('should extact the value of a VersionPicker correctly', () => {
     const value = extractValueFromCustomField(VersionPicker);
-    expect(value).toEqual('1.0,1.1.1,2.0');
+    expect(value).toEqual(['1.0','1.1.1','2.0']);
   });
 });

--- a/src/converters/extractValueFromCustomField.ts
+++ b/src/converters/extractValueFromCustomField.ts
@@ -64,7 +64,7 @@ export function extractValueFromCustomField(value: any): any {
        *   Multi Select
        *   Multi User Picker
        */
-      return value.map(extractValueFromCustomField).join(',');
+      return value.map(extractValueFromCustomField);
     } else {
       return UNABLE_TO_PARSE_RESPONSE;
     }


### PR DESCRIPTION
# Description

Custom Jira fields that involve multiple values will be saved as an array of values instead of a comma-separated string of values.

## Summary

The Mapper will search every array value for matches when making relationships. In order to support making mapping rules off of multi-select custom Jira fields, we want to store these values as arrays instead of a comma-separated string.

## Type of change

Please leave any irrelevant options unchecked.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
