### PR TITLE
Publish '.' instead of './dist'

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "npm",
         {
           "setRcToken": false,
-          "publishFolder": "./dist"
+          "publishFolder": "."
         }
       ],
       "released"


### PR DESCRIPTION
The last build failed because it tried to publish the wrong directory

![Screenshot 2023-04-14 at 3 45 51 PM](https://user-images.githubusercontent.com/15333061/232141193-fc1f6c05-7006-454c-9fbe-f85253b6aad0.png)
