### PR TITLE
Publish release notes in integration-deployment PR

### DIFF
--- a/.github/workflows/integration-deployment.yml
+++ b/.github/workflows/integration-deployment.yml
@@ -26,10 +26,11 @@ jobs:
             const versionNumber = tagName.replace("v", "")
             core.setOutput('versionNumber', versionNumber)
       - name: Bump integration deployment version
-        uses: JupiterOne/integration-github-actions/create-integration-deployment@v1.0.0
+        uses: JupiterOne/integration-github-actions/create-integration-deployment@v1.2.0
         with:
           integrationName:
             ${{ steps.get-integration-name.outputs.integrationName }}
           version: ${{ steps.get-version-number.outputs.versionNumber }}
           githubToken: ${{ secrets.AUTO_GITHUB_PAT_TOKEN }}
           npmAuthToken: ${{ secrets.NPM_AUTH_TOKEN }}
+          releaseNotes: ${{ github.event.release.body }}


### PR DESCRIPTION
Update to `create-integration-deployment@v1.2.0` and add the optional `releaseNotes` property so that release notes and authors are added to the `integration-deployment` PR's description.

E.g. before: 
<img width="842" alt="Screenshot 2023-04-27 at 12 26 13 PM" src="https://user-images.githubusercontent.com/15333061/234928164-d3c47891-d645-49fe-92be-c30ffc688346.png">


after: 
<img width="842" alt="Screenshot 2023-04-27 at 12 25 46 PM" src="https://user-images.githubusercontent.com/15333061/234928070-8ab1b353-8aa4-4242-91a8-433c26d2f650.png">
