### PR TITLE
[APP-12341] Pass action properties via S3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-jira",
-  "version": "3.9.0",
+  "version": "3.8.4",
   "description": "A JupiterOne managed integration for https://www.atlassian.com/software/jira.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-jira",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "prepack": "yarn build"
   },
   "dependencies": {
+    "aws-sdk": "^2.184.0",
     "dotenv": "^10.0.0",
     "jira-client": "^7.1.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-jira",
-  "version": "3.8.4",
+  "version": "3.9.0",
   "description": "A JupiterOne managed integration for https://www.atlassian.com/software/jira.",
   "main": "dist/index.js",
   "repository": "https://github.com/JupiterOne/graph-jira",

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -59,9 +59,10 @@ describe.each([[{ storedActionData: false }], [{ storedActionData: true }]])(
       mockJiraClient.addAttachmentOnIssue = jest.fn().mockResolvedValueOnce({});
 
       mockS3Client.getObject = jest.fn().mockImplementation(() => ({
-        promise: async () => ({
-          Body: JSON.stringify(actionProperties),
-        }),
+        promise: () =>
+          Promise.resolve({
+            Body: JSON.stringify(actionProperties),
+          }),
       }));
 
       actionProperties = {

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -1,6 +1,8 @@
-import { CreateIssueActionProperties, createJiraIssue } from './actions';
 import { Issue } from './jira';
 import largeAdf from '../test/fixtures/large-adf.json';
+
+process.env.JUPITERONE_ENVIRONMENT = 'jupiterone-test';
+import { CreateIssueActionProperties, createJiraIssue } from './actions';
 
 const issueDescriptionText = 'Test description';
 
@@ -23,129 +25,170 @@ const issueDescriptionADF = {
   ],
 };
 
-describe('createJiraIssue', () => {
-  const projectKey = 'PROJ';
-  const projectId = 123456;
+describe.each([[{ storedActionData: false }], [{ storedActionData: true }]])(
+  'createJiraIssue',
+  ({ storedActionData }) => {
+    const projectKey = 'PROJ';
+    const projectId = 123456;
 
-  const createdIssue: Issue = { key: 'PROJ-1' } as any;
-  const foundIssue: Issue = { key: 'PROJ-1' } as any;
+    const createdIssue: Issue = { key: 'PROJ-1' } as any;
+    const foundIssue: Issue = { key: 'PROJ-1' } as any;
 
-  const mockClient = {} as any;
-  const actionProperties: CreateIssueActionProperties = {
-    classification: 'Task',
-    project: String(projectId),
-    summary: 'The Summary',
-    additionalFields: { description: issueDescriptionADF },
-  };
+    const mockJiraClient = {} as any;
+    const mockS3Client = {} as any;
+    let actionProperties: Omit<
+      CreateIssueActionProperties & { storedActionData: false },
+      'storedActionData'
+    >;
 
-  beforeEach(() => {
-    mockClient.apiVersion = '3';
-    mockClient.projectKeyToProjectId = jest.fn().mockResolvedValueOnce(123456);
-    mockClient.addNewIssue = jest.fn().mockResolvedValueOnce(createdIssue);
-    mockClient.findIssue = jest.fn().mockResolvedValueOnce(foundIssue);
-    mockClient.addAttachmentOnIssue = jest.fn().mockResolvedValueOnce({});
-  });
+    function getActionPropertiesToPass(): CreateIssueActionProperties {
+      return storedActionData
+        ? { storedActionData, actionDataS3Key: 'action/data/key' }
+        : { storedActionData, ...actionProperties };
+    }
 
-  test('uses project ID as provided', async () => {
-    const issue = await createJiraIssue(mockClient, {
-      properties: { ...actionProperties, project: String(projectId) },
+    beforeEach(() => {
+      mockJiraClient.apiVersion = '3';
+      mockJiraClient.projectKeyToProjectId = jest
+        .fn()
+        .mockResolvedValueOnce(123456);
+      mockJiraClient.addNewIssue = jest
+        .fn()
+        .mockResolvedValueOnce(createdIssue);
+      mockJiraClient.findIssue = jest.fn().mockResolvedValueOnce(foundIssue);
+      mockJiraClient.addAttachmentOnIssue = jest.fn().mockResolvedValueOnce({});
+
+      mockS3Client.getObject = jest.fn().mockImplementation(() => ({
+        promise: async () => ({
+          Body: JSON.stringify(actionProperties),
+        }),
+      }));
+
+      actionProperties = {
+        classification: 'Task',
+        project: String(projectId),
+        summary: 'The Summary',
+        additionalFields: { description: issueDescriptionADF },
+      };
     });
 
-    expect(mockClient.projectKeyToProjectId).not.toHaveBeenCalled();
-    expect(mockClient.addNewIssue).toHaveBeenCalledWith(
-      expect.objectContaining({
+    afterEach(() => {
+      if (storedActionData) {
+        expect(mockS3Client.getObject).toHaveBeenCalledWith({
+          Bucket: 'jupiterone-test-jupiter-integration-jira-actions',
+          Key: 'action/data/key',
+        });
+        expect(mockS3Client.getObject).toHaveBeenCalledTimes(1);
+      } else {
+        expect(mockS3Client.getObject).toHaveBeenCalledTimes(0);
+      }
+
+      jest.resetAllMocks();
+    });
+
+    test('uses project ID as provided', async () => {
+      actionProperties.project = String(projectId);
+      const issue = await createJiraIssue(mockJiraClient, mockS3Client, {
+        properties: getActionPropertiesToPass(),
+      });
+
+      expect(mockJiraClient.projectKeyToProjectId).not.toHaveBeenCalled();
+      expect(mockJiraClient.addNewIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId,
+        }),
+      );
+
+      expect(issue).toBe(foundIssue);
+    });
+
+    test('converts project key to project ID', async () => {
+      actionProperties.project = projectKey;
+      const issue = await createJiraIssue(mockJiraClient, mockS3Client, {
+        properties: getActionPropertiesToPass(),
+      });
+
+      expect(mockJiraClient.projectKeyToProjectId).toHaveBeenCalledWith(
+        projectKey,
+      );
+      expect(mockJiraClient.addNewIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId,
+        }),
+      );
+
+      expect(issue).toBe(foundIssue);
+    });
+
+    test('uses description ADF for V3 API', async () => {
+      mockJiraClient.apiVersion = 3;
+
+      const issue = await createJiraIssue(mockJiraClient, mockS3Client, {
+        properties: getActionPropertiesToPass(),
+      });
+
+      expect(mockJiraClient.addNewIssue).toHaveBeenCalledWith({
         projectId,
-      }),
-    );
+        issueTypeName: actionProperties.classification,
+        summary: actionProperties.summary,
+        additionalFields: {
+          description: issueDescriptionADF,
+        },
+      });
 
-    expect(issue).toBe(foundIssue);
-  });
-
-  test('converts project key to project ID', async () => {
-    const issue = await createJiraIssue(mockClient, {
-      properties: { ...actionProperties, project: projectKey },
+      expect(mockJiraClient.findIssue).toHaveBeenCalledWith(createdIssue.key);
+      expect(issue).toBe(foundIssue);
     });
 
-    expect(mockClient.projectKeyToProjectId).toHaveBeenCalledWith(projectKey);
-    expect(mockClient.addNewIssue).toHaveBeenCalledWith(
-      expect.objectContaining({
+    test('converts description ADF for V2 API', async () => {
+      mockJiraClient.apiVersion = '2';
+
+      const issue = await createJiraIssue(mockJiraClient, mockS3Client, {
+        properties: getActionPropertiesToPass(),
+      });
+
+      expect(mockJiraClient.addNewIssue).toHaveBeenCalledWith({
         projectId,
-      }),
-    );
+        issueTypeName: actionProperties.classification,
+        summary: actionProperties.summary,
+        additionalFields: {
+          description: issueDescriptionText,
+        },
+      });
 
-    expect(issue).toBe(foundIssue);
-  });
-
-  test('uses description ADF for V3 API', async () => {
-    mockClient.apiVersion = 3;
-
-    const issue = await createJiraIssue(mockClient, {
-      properties: actionProperties,
+      expect(mockJiraClient.findIssue).toHaveBeenCalledWith(createdIssue.key);
+      expect(issue).toBe(foundIssue);
     });
 
-    expect(mockClient.addNewIssue).toHaveBeenCalledWith({
-      projectId,
-      issueTypeName: actionProperties.classification,
-      summary: actionProperties.summary,
-      additionalFields: {
-        description: issueDescriptionADF,
-      },
+    test('does not try to create an attachment for a normal sized description', async () => {
+      mockJiraClient.apiVersion = '3';
+
+      const issue = await createJiraIssue(mockJiraClient, mockS3Client, {
+        properties: getActionPropertiesToPass(),
+      });
+
+      // Should not create attachments unless absolutely necessary
+      expect(mockJiraClient.addAttachmentOnIssue).not.toHaveBeenCalled();
+      expect(issue).toBe(foundIssue);
     });
 
-    expect(mockClient.findIssue).toHaveBeenCalledWith(createdIssue.key);
-    expect(issue).toBe(foundIssue);
-  });
+    test('should add the description as an attachment if it is too large', async () => {
+      mockJiraClient.apiVersion = '3';
+      actionProperties.additionalFields = { description: largeAdf };
 
-  test('converts description ADF for V2 API', async () => {
-    mockClient.apiVersion = '2';
+      const issue = await createJiraIssue(mockJiraClient, mockS3Client, {
+        properties: getActionPropertiesToPass(),
+      });
+      expect(mockJiraClient.addAttachmentOnIssue).toHaveBeenCalled();
 
-    const issue = await createJiraIssue(mockClient, {
-      properties: actionProperties,
+      // Should not create attachments unless absolutely necessary
+      expect(mockJiraClient.addAttachmentOnIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issueId: createdIssue.id,
+          attachmentContent: expect.any(String),
+        }),
+      );
+      expect(issue).toBe(foundIssue);
     });
-
-    expect(mockClient.addNewIssue).toHaveBeenCalledWith({
-      projectId,
-      issueTypeName: actionProperties.classification,
-      summary: actionProperties.summary,
-      additionalFields: {
-        description: issueDescriptionText,
-      },
-    });
-
-    expect(mockClient.findIssue).toHaveBeenCalledWith(createdIssue.key);
-    expect(issue).toBe(foundIssue);
-  });
-
-  test('does not try to create an attachment for a normal sized description', async () => {
-    mockClient.apiVersion = '3';
-
-    const issue = await createJiraIssue(mockClient, {
-      properties: actionProperties,
-    });
-
-    // Should not create attachments unless absolutely necessary
-    expect(mockClient.addAttachmentOnIssue).not.toHaveBeenCalled();
-    expect(issue).toBe(foundIssue);
-  });
-
-  test('should add the description as an attachment if it is too large', async () => {
-    mockClient.apiVersion = '3';
-
-    const issue = await createJiraIssue(mockClient, {
-      properties: {
-        ...actionProperties,
-        additionalFields: { description: largeAdf },
-      },
-    });
-    expect(mockClient.addAttachmentOnIssue).toHaveBeenCalled();
-
-    // Should not create attachments unless absolutely necessary
-    expect(mockClient.addAttachmentOnIssue).toHaveBeenCalledWith(
-      expect.objectContaining({
-        issueId: createdIssue.id,
-        attachmentContent: expect.any(String),
-      }),
-    );
-    expect(issue).toBe(foundIssue);
-  });
-});
+  },
+);

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -113,11 +113,11 @@ type FullCreateIssueActionProperties = Omit<
 function isValidCreateIssueActionProperties(
   actionProperties: any,
 ): actionProperties is FullCreateIssueActionProperties {
-  let valid = !!actionProperties;
-  valid &&= '' < actionProperties.project;
-  valid &&= '' < actionProperties.summary;
-  valid &&= '' < actionProperties.classification;
-  return valid;
+  if (!actionProperties) {
+    return false;
+  }
+  const { project, summary, classification } = actionProperties;
+  return !!project && !!summary && !!classification;
 }
 
 async function getStoredActionData(

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,3 +1,4 @@
+import { S3 } from 'aws-sdk';
 import {
   Issue,
   IssueFields,
@@ -12,6 +13,8 @@ import { markdownToADF } from './utils/markdownToADF';
 const ISSUE_DESCRIPTION_CHARACTER_LIMIT = 32767;
 const DESCRIPTION_WHEN_TOO_LONG =
   'The description exceeded the maximum length allowed by Jira, so JupiterOne has attached the contents as a file to this issue.';
+const jupiteroneEnv = process.env.JUPITERONE_ENVIRONMENT;
+const jiraActionsBucket = 'jupiter-integration-jira-actions';
 
 /**
  * The structure of the `properties` data provided by the JupiterOne Alert Rules
@@ -19,12 +22,18 @@ const DESCRIPTION_WHEN_TOO_LONG =
  *
  * @see createJiraIssue
  */
-export interface CreateIssueActionProperties {
-  project: JiraProjectKey;
-  summary: string;
-  classification: IssueTypeName;
-  additionalFields?: IssueFields;
-}
+export type CreateIssueActionProperties =
+  | {
+      storedActionData?: false;
+      project: JiraProjectKey;
+      summary: string;
+      classification: IssueTypeName;
+      additionalFields?: IssueFields;
+    }
+  | {
+      storedActionData: true;
+      actionDataS3Key: string;
+    };
 
 /**
  * A utility function created for use by the managed runtime.
@@ -37,22 +46,27 @@ export interface CreateIssueActionProperties {
  * simple string containing only that value.
  */
 export async function createJiraIssue(
-  client: JiraClient,
+  jiraClient: JiraClient,
+  s3Client: S3,
   action: { properties: CreateIssueActionProperties; [k: string]: any },
 ): Promise<Issue> {
+  const actionProperties = action.properties.storedActionData
+    ? await getStoredActionData(s3Client, action.properties.actionDataS3Key)
+    : action.properties;
+
   const {
     summary,
     classification: issueTypeName,
     project,
     additionalFields,
-  } = action.properties;
+  } = actionProperties;
 
-  const projectId = await getProjectIdForProjectKey(client, project);
+  const projectId = await getProjectIdForProjectKey(jiraClient, project);
 
   // Check to see if description is too long, if it is, strip it out and put a placeholder
   // in
   const descriptionOverCharacterLimit = isDescriptionOverCharacterLimit(
-    client.apiVersion,
+    jiraClient.apiVersion,
     additionalFields,
   );
 
@@ -61,12 +75,12 @@ export async function createJiraIssue(
     ...additionalFieldsWithoutDescription
   } = additionalFields ?? {};
 
-  const newIssue = await client.addNewIssue({
+  const newIssue = await jiraClient.addNewIssue({
     summary,
     projectId,
     issueTypeName,
     additionalFields: normalizeIssueFields(
-      client.apiVersion,
+      jiraClient.apiVersion,
       // Create the issue without a description if the description is over the character limit
       descriptionOverCharacterLimit
         ? {
@@ -80,7 +94,7 @@ export async function createJiraIssue(
   if (descriptionOverCharacterLimit) {
     // We need to take the description that was too long for the description field, and upload it as an
     // attachment to the issue we just created
-    await client.addAttachmentOnIssue({
+    await jiraClient.addAttachmentOnIssue({
       issueId: newIssue.id,
       attachmentContent: getAttachmentContentFromDescription(
         additionalFieldsDescription,
@@ -89,7 +103,50 @@ export async function createJiraIssue(
   }
 
   // return the issue
-  return client.findIssue(newIssue.key);
+  return jiraClient.findIssue(newIssue.key);
+}
+
+type FullCreateIssueActionProperties = Omit<
+  CreateIssueActionProperties & { storedActionData: false },
+  'storedActionData'
+>;
+function isValidCreateIssueActionProperties(
+  actionProperties: any,
+): actionProperties is FullCreateIssueActionProperties {
+  let valid = !!actionProperties;
+  valid &&= '' < actionProperties.project;
+  valid &&= '' < actionProperties.summary;
+  valid &&= '' < actionProperties.classification;
+  return valid;
+}
+
+async function getStoredActionData(
+  s3Client: S3,
+  actionDataS3Key: string,
+): Promise<FullCreateIssueActionProperties> {
+  if (!jupiteroneEnv) {
+    throw new Error('Environment variable JUPITERONE_ENVIRONMENT must be set.');
+  }
+  const { Body: s3ObjectBody } = await s3Client
+    .getObject({
+      Bucket: `${jupiteroneEnv}-${jiraActionsBucket}`,
+      Key: actionDataS3Key,
+    })
+    .promise();
+
+  if (!s3ObjectBody) {
+    throw new Error('Could not fetch action data.');
+  }
+
+  const actionProperties = JSON.parse(
+    s3ObjectBody.toString('utf-8'),
+  ) as unknown;
+  if (!isValidCreateIssueActionProperties(actionProperties)) {
+    throw new Error(
+      'Fetched action data does not contain expected properties.',
+    );
+  }
+  return actionProperties;
 }
 
 async function getProjectIdForProjectKey(


### PR DESCRIPTION
# Description

Adds a path to invoke the CREATE_ENTITY action with Jira issue properties in an S3 object. This enables us to work around the AWS Lambda payload size limit of 6mb.

## Summary

- Changed `CreateIssueActionProperties` to a union type representing backward-compatible and new S3-backed invocation types.
- Added new invocation type to test suite

## Type of change

Please leave any irrelevant options unchecked.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [x] This change requires a documentation update

## Checklist

### General Development Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
