### PR TITLE
Make API version an optional config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,7 @@ export const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
   jiraApiVersion: {
     type: 'string',
     mask: false,
+    optional: true,
   },
   jiraUsername: {
     type: 'string',


### PR DESCRIPTION
# Description
The API version is treated as an optional config in the code but not in the integration invocation config validator.


