### PR TITLE
Optional redactIssueDescriptions field

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -142,6 +142,10 @@ export async function validateInvocation(
 ) {
   const { config } = context.instance;
 
+  if (config.redactIssueDescriptions === undefined) {
+    config.redactIssueDescriptions = false;
+  }
+
   if (!config.jiraHost || !config.jiraPassword || !config.jiraUsername) {
     throw new IntegrationValidationError(
       'Config requires all of {jiraHost, jiraUsername, jiraPassword}',

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,7 +100,7 @@ export interface JiraIntegrationInstanceConfig
   /**
    * Defaults to false. Set to true if you would like issue descriptions to be redacted in jira_issue entities.
    */
-  redactIssueDescriptions: boolean;
+  redactIssueDescriptions?: boolean;
 
   /**
    * An optional array of Jira Custom Field identifiers, indicating which custom

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,7 @@ export const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
   redactIssueDescriptions: {
     type: 'boolean',
     mask: false,
+    optional: true,
   },
   projects: {
     type: 'string',

--- a/src/steps/issues.ts
+++ b/src/steps/issues.ts
@@ -77,7 +77,7 @@ export async function fetchIssues({
         fieldsById,
         customFieldsToInclude: config.customFields,
         projectEntities,
-        redactIssueDescriptions,
+        redactIssueDescriptions: redactIssueDescriptions ?? false,
         apiVersion,
       },
       projectKey,


### PR DESCRIPTION
Make the field optional to make the integration SDK happy when it's not sent.  It will default to the correct value.