### PR TITLE
Fixing normalizing projects

### DIFF
--- a/src/utils/builders.ts
+++ b/src/utils/builders.ts
@@ -32,7 +32,7 @@ export function normalizeProjectKeys(
       const parsedProjects = JSON.parse(projects);
       return normalizeProjectKeys(parsedProjects);
     } catch (err) {
-      // Some configs such as the collector recieves the projects field as [PROJECT]
+      // Some configs such as the collector receives the projects field as PROJECTS=[INT JPT]
       if (projects.includes('[') && projects.includes(']')) {
         projects = projects.replace('[', '').replace(']', '').split(' ');
         return normalizeProjectKeys(projects);

--- a/src/utils/builders.ts
+++ b/src/utils/builders.ts
@@ -32,6 +32,11 @@ export function normalizeProjectKeys(
       const parsedProjects = JSON.parse(projects);
       return normalizeProjectKeys(parsedProjects);
     } catch (err) {
+      // Some configs such as the collector recieves the projects field as [PROJECT]
+      if (projects.includes('[') && projects.includes(']')) {
+        projects = projects.replace('[', '').replace(']', '').split(' ');
+        return normalizeProjectKeys(projects);
+      }
       return normalizeProjectKeys([projects]);
     }
   } else {


### PR DESCRIPTION
The "Projects field" when sent down outside of managed integrations looks like this: 
```
                "PROJECTS=[INT JPT]",
```

We need to handle this case.