### PR TITLE
NO-TICKET Import lodash/camelCase

### DIFF
--- a/src/utils/builders.ts
+++ b/src/utils/builders.ts
@@ -1,4 +1,4 @@
-import { camelCase } from 'lodash';
+import camelCase from 'lodash/camelCase';
 
 import { JiraProjectKey } from '../jira';
 


### PR DESCRIPTION
According to [documentation](https://www.npmjs.com/package/lodash), you are supposed to import lodash packages using 'lodash/X'. Just importing 'lodash' will cause the entire package to be bundled. Removing the entire package and just using the functions we need should hopefully reduce this project's size so we can deploy with o11y again.
